### PR TITLE
Improving type constraints

### DIFF
--- a/Natery.MultiPhaseProcessor/Natery.MultiPhaseProcessor.Test/Test_Processor.cs
+++ b/Natery.MultiPhaseProcessor/Natery.MultiPhaseProcessor.Test/Test_Processor.cs
@@ -83,6 +83,14 @@ namespace Natery.MultiPhaseProcessor.Test
             CollectionAssert.AreEquivalent(new string[] { "10", "11", "12", "20", "21", "22", "30", "31", "32" }, list);
         }
 
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Processor_InvalidHeadProcessee_ThrowsException()
+        {
+            var p = new Processor<string>();
+            p.WithProcessee<int, int>((i) => Task.FromResult(1));
+        }
+
         //#14: Value types fail because of 'default' keyword for queue usage
         [Ignore]
         [TestMethod]

--- a/Natery.MultiPhaseProcessor/Natery.MultiPhaseProcessor/IProcessee.cs
+++ b/Natery.MultiPhaseProcessor/Natery.MultiPhaseProcessor/IProcessee.cs
@@ -2,18 +2,22 @@
 
 namespace Natery.MultiPhaseProcessor
 {
-    internal interface IProcessee<TInput, TOutput> : IProcessee<TInput>
+    internal interface IProcessee<TInput, TOutput> : IProcesseeWithInput<TInput>, IProcesseeWithOutput<TOutput>
     {
     }
 
-    internal interface IProcessee<TInput> : IProcessee
+    internal interface IProcesseeWithInput<TInput> : IProcessee
     {
         void AddWorkItem(TInput workItem);
     }
 
+    internal interface IProcesseeWithOutput<TOutput> : IProcessee
+    {
+        void AddNext(IProcesseeWithInput<TOutput> processee);
+    }
+
     internal interface IProcessee
     {
-        void AddNext(IProcessee processee);
         Task BeginProcessingAsync();
         void NoMoreWorkToAdd();
     }

--- a/Natery.MultiPhaseProcessor/Natery.MultiPhaseProcessor/Processee.cs
+++ b/Natery.MultiPhaseProcessor/Natery.MultiPhaseProcessor/Processee.cs
@@ -7,7 +7,7 @@ namespace Natery.MultiPhaseProcessor
 {
     internal class Processee<TInput, TOutput> : IProcessee<TInput, TOutput>
     {
-        internal IProcessee _next;
+        internal IProcesseeWithInput<TOutput> _next;
         internal ConcurrentQueue<TInput> _queue;
         internal bool _moreWorkToAdd;
         internal Func<TInput, Task<TOutput>> _action;
@@ -22,7 +22,7 @@ namespace Natery.MultiPhaseProcessor
             _maxDegreesOfParallelism = maxDegreesOfParallelism;
         }
 
-        public void AddNext(IProcessee processee)
+        public void AddNext(IProcesseeWithInput<TOutput> processee)
         {
             _next = processee;
         }
@@ -56,7 +56,7 @@ namespace Natery.MultiPhaseProcessor
             {
                 var output = _action(actionInput).Result;
                 if (_next != null)
-                    ((IProcessee<TOutput>)_next).AddWorkItem(output);
+                    _next.AddWorkItem(output);
 
                 progress++;
             }, new ExecutionDataflowBlockOptions() { MaxDegreeOfParallelism = _maxDegreesOfParallelism });

--- a/Natery.MultiPhaseProcessor/Natery.MultiPhaseProcessor/Processor.cs
+++ b/Natery.MultiPhaseProcessor/Natery.MultiPhaseProcessor/Processor.cs
@@ -6,10 +6,8 @@ namespace Natery.MultiPhaseProcessor
 {
     public class Processor<TInput>
     {
-        internal IProcessee<TInput> _head;
+        internal IProcesseeWithInput<TInput> _head;
         internal IProcessee _lastAdded;
-
-        public Processor() { }
 
         public Processor<TInput> WithProcessee<TProcesseeInput, TProcesseeOutput>(
             Func<TProcesseeInput, Task<TProcesseeOutput>> action, 
@@ -17,9 +15,13 @@ namespace Natery.MultiPhaseProcessor
         {
             var processee = new Processee<TProcesseeInput, TProcesseeOutput>(action, maxDegreesOfParallelism);
             if (_lastAdded == null)
-                _head = (IProcessee<TInput>)processee;
+            {
+                if (!typeof(TInput).IsAssignableFrom(typeof(TProcesseeInput)))
+                    throw new ArgumentException($"Processee function contains invalid input type parameter for the Processor");
+                _head = (IProcesseeWithInput<TInput>)processee;
+            }
             else
-                _lastAdded.AddNext(processee);
+                ((IProcesseeWithOutput<TProcesseeInput>)_lastAdded).AddNext(processee);
             
             _lastAdded = processee;
 


### PR DESCRIPTION
Improving type constraints. I added two new interfaces for the Input and Output sides of the Processee so that the methods could be associated with those interfaces to lock down the types more.

Closes #27
